### PR TITLE
Delete posts

### DIFF
--- a/Back-end/index.js
+++ b/Back-end/index.js
@@ -154,13 +154,31 @@ app.get("/commentcount/:id", async (req, res) => {
 });
 
 app.get("/posts", async (req, res) => {
-  const userId = res.locals.id;
   const posts = await prisma.posts.findMany({
-    where: {
-      userId: userId,
+    orderBy: {
+      Post_id: "asc",
     },
   });
   res.json(posts);
+});
+app.delete("/post", async (req, res) => {
+  const Post_id = parseInt(req.body.Post_id);
+  const comments = await prisma.comments.deleteMany({
+    where: {
+      Post_id: Post_id,
+    },
+  });
+  const likes = await prisma.like.deleteMany({
+    where: {
+      Post_id: Post_id,
+    },
+  });
+  const post = await prisma.posts.deleteMany({
+    where: {
+      Post_id: Post_id,
+    },
+  });
+  res.json(post);
 });
 app.post("/post", async (req, res) => {
   const { description, title, userId } = req.body;

--- a/Front-end/src/components/Post.css
+++ b/Front-end/src/components/Post.css
@@ -88,5 +88,5 @@ footer {
 .delete {
   position: absolute;
   top: 0;
-  right: 0; 
+  right: 0;
 }

--- a/Front-end/src/components/Post.css
+++ b/Front-end/src/components/Post.css
@@ -84,3 +84,9 @@ footer {
 .logo {
   width: 26px;
 }
+
+.delete {
+  position: absolute;
+  top: 0;
+  right: 0; 
+}

--- a/Front-end/src/components/Post.jsx
+++ b/Front-end/src/components/Post.jsx
@@ -3,7 +3,7 @@ import "./Post.css";
 import "semantic-ui-css/semantic.min.css";
 
 import moment from "moment";
-import { Icon, CommentGroup, Form } from "semantic-ui-react";
+import { Button, Icon, CommentGroup, Form } from "semantic-ui-react";
 import Comment from "./sub-component/Comment";
 
 const Post = (props) => {
@@ -106,6 +106,19 @@ const Post = (props) => {
       })
     );
   }
+  function deletePost() {
+    fetch(`http://localhost:3000/post`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "Application/json",
+      },
+      body: JSON.stringify({ Post_id: props.id })
+    }).then((data) =>
+      data.json().then((data) => {
+
+      })
+    );
+  }
 
   function getComments() {
     fetch(`http://localhost:3000/comments/${props.id}`, {
@@ -184,6 +197,11 @@ const Post = (props) => {
           <Icon onClick={handleLike} className="like" name={like}>
             {likecount}
           </Icon>
+          {user.id === props.userid && (
+            <Button icon className="delete" color="red" onClick={deletePost}>
+              <Icon name="trash alternate"></Icon>
+            </Button>
+          )}
         </footer>
         <hr />
       </div>

--- a/Front-end/src/components/Post.jsx
+++ b/Front-end/src/components/Post.jsx
@@ -112,12 +112,8 @@ const Post = (props) => {
       headers: {
         "Content-Type": "Application/json",
       },
-      body: JSON.stringify({ Post_id: props.id })
-    }).then((data) =>
-      data.json().then((data) => {
-
-      })
-    );
+      body: JSON.stringify({ Post_id: props.id }),
+    }).then((data) => data.json().then((data) => {}));
   }
 
   function getComments() {


### PR DESCRIPTION
Users can now delete posts they created using the UI.

The project checks if the id of the author of the post and the person logged in are the same in order to render the delete button. 

TEST CASE:
Generate a new post.
<img width="1714" alt="Screenshot 2024-07-17 at 2 33 42 PM" src="https://github.com/user-attachments/assets/d7aec91d-3cf6-434c-9a6c-ab51bc158c4d">
Check that the delete button does not render for posts made by other users
<img width="1168" alt="Screenshot 2024-07-17 at 2 34 07 PM" src="https://github.com/user-attachments/assets/ada9588f-c686-4fe7-920b-2794cd4e2218">
Add comments and likes
<img width="1093" alt="Screenshot 2024-07-17 at 2 50 45 PM" src="https://github.com/user-attachments/assets/4ffbad4c-e91c-4417-bca6-126e54dca74d">
The post deletes the likecounts and comments before deleting itself
<img width="1481" alt="Screenshot 2024-07-17 at 2 51 19 PM" src="https://github.com/user-attachments/assets/16ff3102-3e88-4d0e-956e-bdb7daf67195">

