### PR TITLE
Corner Case for routing GPS

### DIFF
--- a/Front-end/src/Meetup.jsx
+++ b/Front-end/src/Meetup.jsx
@@ -186,6 +186,10 @@ const Meetup = () => {
               location
                 .json()
                 .then((location) => {
+                  if(location.message && location.message === "No path could be found for input"){
+                    setIsLoading(false);
+                    return alert("No path can be found for the input. Please meet through zoom.")
+                  }
                   //Coordinates store every waypoint that a car would be in the route throughout the trip
                   let coordinates =
                     location.features[0].geometry.coordinates[0];


### PR DESCRIPTION
Added code to alert the user for a corner case if one of the users live in an area that cannot be reached through driving.

TEST CASE: 
Connect with a mentor who lives in an area that you cannot reach by car (in the example I put a mentor's coordinates on Angel Island and disabled the range condition for this test case). The program will alert the user that they cannot meet and to schedule a zoom meeting.
<img width="1719" alt="Screenshot 2024-07-25 at 6 34 31 PM" src="https://github.com/user-attachments/assets/ad97c285-d9c1-479f-b255-66649cb62837">

<img width="1541" alt="Screenshot 2024-07-25 at 6 34 38 PM" src="https://github.com/user-attachments/assets/12a8e608-c328-4568-8493-865264f0a0f3">
